### PR TITLE
Fix RPATH for CVMFS (ilc.desy.de) installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,12 @@ IF( CED_SERVER )
     IF( NOT CED_NOT_INCLUDE_OPENGL_LINKER_PATH ) 
       FOREACH( _opengl_lib ${OPENGL_LIBRARIES} )
         GET_FILENAME_COMPONENT( _opengl_lib_path ${_opengl_lib} PATH )
-        LIST( APPEND _opengl_linker_paths ${_opengl_lib_path} )
+        # the RPATH to be used when installing, but only if it's not a system directory
+        LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES ${_opengl_lib_path} isSystemDir)
+        #MESSAGE( "isSystemDir: ${isSystemDir}" )
+        IF("${isSystemDir}" STREQUAL "-1")
+          LIST( APPEND _opengl_linker_paths ${_opengl_lib_path} )
+        ENDIF("${isSystemDir}" STREQUAL "-1")
       ENDFOREACH()
 
     # remove duplicate paths


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix RPATH for CVMFS (ilc.desy.de) installation
 - Do not add the system directory "/usr/lib64" into the executable files "glced" RPATH list, it will be able to find the right "libstdc++.so.6" from CERN CVMFS compiler with "LD_LIBRARY_PATH" setup.
 - It cannot have influence on sim/reco.

ENDRELEASENOTES