### PR TITLE
Allow build on CYGWIN and test programs use non default CED_PORT if defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-########################################################
+#######################################################
 # cmake file for building CED
 # @author Jan Engels, Desy IT
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)
@@ -123,12 +123,16 @@ IF( CED_SERVER )
 
     INSTALL( TARGETS glced DESTINATION bin )
 
+    # Install dll in bin directory in the case of CYGWIN
+    IF( CYGWIN )
+       INSTALL( TARGETS CED DESTINATION bin )
+    ENDIF()
+
 ENDIF( CED_SERVER )
 
 
 # ------------------ CED TESTS ------------------
-#FOREACH( _testname test_ced test_ced_mhits test_ced_color )
-FOREACH( _testname test_ced test_ced_mhits )
+FOREACH( _testname test_ced test_ced_mhits test_ced_color )
 
     IF( BUILD_TESTING )
         ADD_EXECUTABLE( ${_testname} ./src/tests/${_testname}.cc )

--- a/src/client/glut_socks.cc
+++ b/src/client/glut_socks.cc
@@ -115,7 +115,11 @@ static void tcp_server_accept(struct __glutSocketList *list){
   int fd;
   tcp_srv_sock *nl;
   struct sockaddr_in myclient;  
+#if defined(__CYGWIN__)
+  socklen_t size=sizeof(myclient);
+#else
   unsigned int size=sizeof(myclient);
+#endif
 ;
   
 

--- a/src/server/ced_srv.cc
+++ b/src/server/ced_srv.cc
@@ -37,7 +37,9 @@
 
 #define PORT  0x1234
 #define PI 3.14159265358979323846f 
-
+#if defined(__CYGWIN__)
+#define M_PI 3.14159265358979323846f
+#endif
 
 //hauke
 //int graphic[3];

--- a/src/server/glced.cc
+++ b/src/server/glced.cc
@@ -81,6 +81,9 @@ static GLfloat window_width=0.;
 static GLfloat window_height=0.;
 
 #include <ced_menu.h>
+#if defined(__CYGWIN__)
+#define M_PI 3.14159265358979323846f
+#endif
 
 
 #define DEFAULT_WORLD_SIZE 1000.  //SJA:FIXED Reduce world size to give better scale

--- a/src/tests/test_ced.cc
+++ b/src/tests/test_ced.cc
@@ -1,5 +1,9 @@
 #include <ced_cli.h>
 #include <math.h>
+#if defined(__CYGWIN__)
+#define M_SQRT2 1.4142135623730950
+#endif
+#include <stdio.h>
 
 double length = 100;
 
@@ -17,7 +21,15 @@ int main(){
 
 	/*
 	 * Initialisation */
-  	ced_client_init("localhost",7286);
+        char *p;
+        p = getenv("CED_PORT");
+        if(p != NULL){
+            printf("Try to use user defined port %s.\n", p);
+            ced_client_init("localhost",atoi(p));
+        }else{
+            printf("CED_PORT undefined. Using CED_PORT=7286.\n");
+            ced_client_init("localhost",7286);
+        }
   	ced_register_elements();
   
   	/*

--- a/src/tests/test_ced_color.cc
+++ b/src/tests/test_ced_color.cc
@@ -1,6 +1,8 @@
 #include <ced_cli.h>
 #include <math.h>
 #include <iostream>
+#include <stdlib.h>
+#include <stdio.h>
 
 double length = 5;
 
@@ -18,7 +20,16 @@ int main(){
 
 	/*
 	 * Initialisation */
-  	ced_client_init("localhost",20131);
+        char *p;
+        p = getenv("CED_PORT");
+        if(p != NULL){
+            printf("Try to use user defined port %s.\n", p);
+            ced_client_init("localhost",atoi(p));
+        }else{
+            printf("CED_PORT undefined. Using CED_PORT=7286.\n");
+            ced_client_init("localhost",7286);
+        }
+
   	ced_register_elements();
   
   	/*

--- a/src/tests/test_ced_mhits.cc
+++ b/src/tests/test_ced_mhits.cc
@@ -11,7 +11,15 @@ int main(){
   
   /*
    * Initialisation */
-  ced_client_init("localhost",7286);
+  char *p;
+  p = getenv("CED_PORT");
+  if(p != NULL){
+      printf("Try to use user defined port %s.\n", p);
+      ced_client_init("localhost",atoi(p));
+  }else{
+      printf("CED_PORT undefined. Using CED_PORT=7286.\n");
+      ced_client_init("localhost",7286);
+  }
   ced_register_elements();
   
   time_t t;


### PR DESCRIPTION
BEGINRELEASENOTES
-  Included corrections to build CED server and test programs on CYGWIN.
-  Test programs use non default CED_PORT, if it is defined by the environment parameters.  Default is 7286.
-  The default CED_PORT of test_ced_color is 7286 instead of 20131.  A value by the environment parameter is used if defined.
ENDRELEASENOTES