### PR TITLE
Remove CentOS7 from the CI workflows for Key4hep

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22", "centos7"]
+        image: ["alma9", "ubuntu22"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove CentOS7 from the Key4hep based CI workflows

ENDRELEASENOTES