### PR TITLE
Fix warnings

### DIFF
--- a/include/ced_menu.h
+++ b/include/ced_menu.h
@@ -727,13 +727,12 @@ class CED_PopUpMenu{
                          //selected_submenu->mouseOver();
                      }
 
-                    unsigned i;
-                    for(i=0;(unsigned) i<subsubMenus.size();i++){
-                        subsubMenus.at(i)->x_start=x_start;
-                        subsubMenus.at(i)->x_end  =x_end;
-                        subsubMenus.at(i)->y_start=y_start/*+height */+1+height*i;
-                        subsubMenus.at(i)->y_end  =y_end  /*+ height*/+1+height*i;
-                        subsubMenus.at(i)->draw();
+                    for(unsigned i2=0;(unsigned) i2<subsubMenus.size();i2++){
+                        subsubMenus.at(i2)->x_start=x_start;
+                        subsubMenus.at(i2)->x_end  =x_end;
+                        subsubMenus.at(i2)->y_start=y_start/*+height */+1+height*i;
+                        subsubMenus.at(i2)->y_end  =y_end  /*+ height*/+1+height*i;
+                        subsubMenus.at(i2)->draw();
                     }
                 }
             glEnable(GL_DEPTH_TEST);

--- a/include/ced_menu.h
+++ b/include/ced_menu.h
@@ -295,12 +295,10 @@ class CED_SubSubMenu{
             subsub->y_end  =y_end + height;
             subsubMenus.push_back(subsub);
         }
-        CED_SubSubMenu(string t, int nr=0){
-            title=t;
-            optionNr=nr;
-            isExtend=false;
-            isMouseOver=false;
-            dead=false;
+        CED_SubSubMenu(string t, int nr=0)
+          : title(t),
+            optionNr(nr)
+        {
         }
         ~CED_SubSubMenu(){
             if(dead == true){
@@ -317,20 +315,20 @@ class CED_SubSubMenu{
         }
 
 
-        bool isAktive;
+        bool isAktive = false;
         string title;
         int optionNr;
-        bool isExtend;
-        bool isMouseOver;
-        int x_start;
-        int x_end;
-        int y_start;
-        int y_end;
+        bool isExtend = false;
+        bool isMouseOver = false;
+        int x_start = 0;
+        int x_end = 0;
+        int y_start = 0;
+        int y_end = 0;
 
-        bool dead;
+        bool dead = false;
 
     private:
-        vector<CED_SubSubMenu *> subsubMenus;
+        vector<CED_SubSubMenu *> subsubMenus{};
 };
 
 
@@ -469,12 +467,10 @@ class CED_SubMenu{
             subsubMenus.push_back(subsub);
 
         }
-        CED_SubMenu(string t, int nr=0){
-            title=t;
-            optionNr=nr;
-            isExtend=false;
-            isMouseOver=false;
-            selected_submenu=NULL;
+        CED_SubMenu(string t, int nr=0)
+          : title(t),
+            optionNr(nr)
+        {
         }
         ~CED_SubMenu(){
             for(int i=0;(unsigned) i<subsubMenus.size();i++){
@@ -483,21 +479,23 @@ class CED_SubMenu{
             }
         }
 
+       CED_SubMenu(const CED_SubMenu&) = delete;
+       CED_SubMenu& operator=(const CED_SubMenu&) = delete;
 
 
         string title;
         int optionNr;
-        bool isExtend;
-        bool isMouseOver;
-        int x_start;
-        int x_end;
-        int y_start;
-        int y_end;
+        bool isExtend = false;
+        bool isMouseOver = false;
+        int x_start = 0;
+        int x_end = 0;
+        int y_start = 0;
+        int y_end = 0;
 
 
     private:
-        CED_SubSubMenu *selected_submenu;
-        vector<CED_SubSubMenu *> subsubMenus;
+        CED_SubSubMenu *selected_submenu = nullptr;
+        vector<CED_SubSubMenu *> subsubMenus{};
 };
 
 class CED_Menu{
@@ -633,8 +631,9 @@ class CED_Menu{
             subMenus.push_back(sub);
             x_offset+=5;
         }
-        CED_Menu(){
-            x_offset=1;
+        CED_Menu()
+          : x_offset(1)
+        {
         }
         ~CED_Menu(){
             cout << "delete ced menu" <<  endl;
@@ -644,7 +643,7 @@ class CED_Menu{
         }
 
     private:
-        vector<CED_SubMenu *> subMenus;
+        vector<CED_SubMenu *> subMenus{};
         unsigned x_offset;
 };
 
@@ -806,33 +805,32 @@ class CED_PopUpMenu{
             subsubMenus.push_back(subsub);
 
         }
-        CED_PopUpMenu(string t, int nr=0){
-            title=t;
-            optionNr=nr;
-            isExtend=false;
-            isMouseOver=false;
-            selected_submenu=NULL;
-            //click_x=
-            //click_y=
+        CED_PopUpMenu(string t, int nr=0)
+          : title(t),
+            optionNr(nr)
+        {
         }
+
+        CED_PopUpMenu(const CED_PopUpMenu&) = delete;
+        CED_PopUpMenu& operator=(const CED_PopUpMenu&) = delete;
 
         int size(void){
             return(subsubMenus.size());
         }
         string title;
         int optionNr;
-        bool isExtend;
-        bool isMouseOver;
-        int x_start;
-        int x_end;
-        int y_start;
-        int y_end;
-        int x_click;
-        int y_click;
+        bool isExtend = false;
+        bool isMouseOver = false;
+        int x_start = 0;
+        int x_end = 0;
+        int y_start = 0;
+        int y_end = 0;
+        int x_click = 0;
+        int y_click = 0;
 
     private:
-        vector<CED_SubSubMenu *> subsubMenus;
-        CED_SubSubMenu *selected_submenu;
+        vector<CED_SubSubMenu *> subsubMenus{};
+        CED_SubSubMenu *selected_submenu = nullptr;
 
 };
 

--- a/src/server/ced_srv.cc
+++ b/src/server/ced_srv.cc
@@ -66,7 +66,12 @@ extern int selected_layer;
 //#define IS_VISIBLE(x) ((1<<((x>>8)&0xff))&ced_visible_layers)
 //#define IS_VISIBLE(x) ((x < (CED_MAX_LAYER-1) && x >= 0)?ced_visible_layers[x]:false)
 
-#define IS_VISIBLE(x) ((x < (CED_MAX_LAYER-1) && x >= 0)?setting.layer[x]:false)
+inline
+bool IS_VISIBLE(int x)
+{
+  if (x < (CED_MAX_LAYER-1) && x >= 0) return setting.layer[x];
+  return false;
+}
 
 
 /*
@@ -426,15 +431,15 @@ void drawPartialLineCylinder(double length, double R /*radius*/, double iR /*inn
             double phi2=360.0/edges*(i-1);
 
             if(360.0-phi <= angle_cut_off){
-                double x = cos(2*PI/edges/2)/cos((360.0- (phi-360.0/edges/2)-angle_cut_off)*2*PI/360.0);
+                double x2 = cos(2*PI/edges/2)/cos((360.0- (phi-360.0/edges/2)-angle_cut_off)*2*PI/360.0);
 
                 if(outer_face){
                     //outer
                     glBegin(GL_LINE_LOOP);
                     glVertex3d(R*sin(phi2*2*PI/360.0), R*cos(phi2*2*PI/360.0),-length/2);
                     glVertex3d(R*sin(phi2*2*PI/360.0), R*cos(phi2*2*PI/360.0),length/2);
-                    glVertex3d(R*x*sin((360.0-angle_cut_off)*2*PI/360.0), R*x*cos((360.0-angle_cut_off)*2*PI/360.0), length/2);
-                    glVertex3d(R*x*sin((360.0-angle_cut_off)*2*PI/360.0), R*x*cos((360.0-angle_cut_off)*2*PI/360.0), -length/2);
+                    glVertex3d(R*x2*sin((360.0-angle_cut_off)*2*PI/360.0), R*x2*cos((360.0-angle_cut_off)*2*PI/360.0), length/2);
+                    glVertex3d(R*x2*sin((360.0-angle_cut_off)*2*PI/360.0), R*x2*cos((360.0-angle_cut_off)*2*PI/360.0), -length/2);
                     glEnd();
                 }
 
@@ -444,8 +449,8 @@ void drawPartialLineCylinder(double length, double R /*radius*/, double iR /*inn
                         glBegin(GL_LINE_LOOP);
                         glVertex3d(iR*sin(phi2*2*PI/360.0), iR*cos(phi2*2*PI/360.0),-length/2);
                         glVertex3d(iR*sin(phi2*2*PI/360.0), iR*cos(phi2*2*PI/360.0),length/2);
-                        glVertex3d(iR*x*sin((360.0-angle_cut_off)*2*PI/360.0), iR*x*cos((360.0-angle_cut_off)*2*PI/360.0), length/2);
-                        glVertex3d(iR*x*sin((360.0-angle_cut_off)*2*PI/360.0), iR*x*cos((360.0-angle_cut_off)*2*PI/360.0), -length/2);
+                        glVertex3d(iR*x2*sin((360.0-angle_cut_off)*2*PI/360.0), iR*x2*cos((360.0-angle_cut_off)*2*PI/360.0), length/2);
+                        glVertex3d(iR*x2*sin((360.0-angle_cut_off)*2*PI/360.0), iR*x2*cos((360.0-angle_cut_off)*2*PI/360.0), -length/2);
                         glEnd();
                     }
                 }
@@ -490,6 +495,7 @@ void drawPartialLineCylinder(double length, double R /*radius*/, double iR /*inn
  */
 
 struct my_point {
+                my_point(double the_x, double the_y) : x(the_x), y(the_y) {}
                 double x;
                 double y;
                 };
@@ -667,15 +673,15 @@ void drawPartialCylinder(double length, double R /*radius*/, double iR /*inner r
         double phi2=360.0/edges*(i-1);
 
         if(360.0-phi <= angle_cut_off){
-            double x = cos(2*PI/edges/2)/cos((360.0- (phi-360.0/edges/2)-angle_cut_off)*2*PI/360.0);
+            double x2 = cos(2*PI/edges/2)/cos((360.0- (phi-360.0/edges/2)-angle_cut_off)*2*PI/360.0);
 
             if(outer_face == true){
                 //outer
 
                 struct point3d p1 = {R*sin(phi2*2*PI/360.0), R*cos(phi2*2*PI/360.0),-length/2};
                 struct point3d p2 = {R*sin(phi2*2*PI/360.0), R*cos(phi2*2*PI/360.0),length/2};
-                struct point3d p3 = {R*x*sin((360.0-angle_cut_off)*2*PI/360.0), R*x*cos((360.0-angle_cut_off)*2*PI/360.0), length/2};
-                struct point3d p4 = {R*x*sin((360.0-angle_cut_off)*2*PI/360.0), R*x*cos((360.0-angle_cut_off)*2*PI/360.0), -length/2};
+                struct point3d p3 = {R*x2*sin((360.0-angle_cut_off)*2*PI/360.0), R*x2*cos((360.0-angle_cut_off)*2*PI/360.0), length/2};
+                struct point3d p4 = {R*x2*sin((360.0-angle_cut_off)*2*PI/360.0), R*x2*cos((360.0-angle_cut_off)*2*PI/360.0), -length/2};
                 struct point3d n;    
                 calNormals(n,p1,p2,p3);
 
@@ -690,8 +696,8 @@ void drawPartialCylinder(double length, double R /*radius*/, double iR /*inner r
                 //glBegin(GL_QUADS);
                 //glVertex3d(R*sin(phi2*2*PI/360.0), R*cos(phi2*2*PI/360.0),-length/2);
                 //glVertex3d(R*sin(phi2*2*PI/360.0), R*cos(phi2*2*PI/360.0),length/2);
-                //glVertex3d(R*x*sin((360.0-angle_cut_off)*2*PI/360.0), R*x*cos((360.0-angle_cut_off)*2*PI/360.0), length/2);
-                //glVertex3d(R*x*sin((360.0-angle_cut_off)*2*PI/360.0), R*x*cos((360.0-angle_cut_off)*2*PI/360.0), -length/2);
+                //glVertex3d(R*x2*sin((360.0-angle_cut_off)*2*PI/360.0), R*x2*cos((360.0-angle_cut_off)*2*PI/360.0), length/2);
+                //glVertex3d(R*x2*sin((360.0-angle_cut_off)*2*PI/360.0), R*x2*cos((360.0-angle_cut_off)*2*PI/360.0), -length/2);
                 //glEnd();
             }
 
@@ -894,7 +900,8 @@ void drawPartialCylinder(double length, double R /*radius*/, double iR /*inner r
 
 
             //inner_side_points.push_back((my_point){iR*sin(360.0/edges*(i)*2*PI/360.0),iR*cos(360.0/edges*(i)*2*PI/360.0)});
-            inner_side_points.push_back((my_point){iR*xl*sin((angle_cut_off_left)*2*PI/360.0),iR*xl*cos((angle_cut_off_left)*2*PI/360.0)});
+            inner_side_points.emplace_back(iR*xl*sin((angle_cut_off_left)*2*PI/360.0),
+                                           iR*xl*cos((angle_cut_off_left)*2*PI/360.0));
 
             i=i+1; 
 
@@ -903,13 +910,13 @@ void drawPartialCylinder(double length, double R /*radius*/, double iR /*inner r
                 phi=360.0/edges*i;
                 if(360.0-phi <= angle_cut_off){
                     x = cos(2*PI/edges/2)/cos((360.0- (phi-360.0/edges/2)-angle_cut_off)*2*PI/360.0);
-                    inner_side_points.push_back((my_point){iR*sin(360.0/edges*(i-1)*2*PI/360.0), iR*cos(360.0/edges*(i-1)*2*PI/360.0)});
-                    inner_side_points.push_back((my_point){iR*x*sin((360.0-angle_cut_off)*2*PI/360.0), iR*x*cos((360.0-angle_cut_off)*2*PI/360.0)});
+                    inner_side_points.emplace_back(iR*sin(360.0/edges*(i-1)*2*PI/360.0), iR*cos(360.0/edges*(i-1)*2*PI/360.0));
+                    inner_side_points.emplace_back(iR*x*sin((360.0-angle_cut_off)*2*PI/360.0), iR*x*cos((360.0-angle_cut_off)*2*PI/360.0));
                     break;
                 }else{
                     if(i != 0){
-                        inner_side_points.push_back((my_point){iR*sin(360.0/edges*(i-1)*2*PI/360.0), iR*cos(360.0/edges*(i-1)*2*PI/360.0)});
-                        inner_side_points.push_back((my_point){iR*sin(phi*2*PI/360.0), iR*cos(phi*2*PI/360.0)});
+                        inner_side_points.emplace_back(iR*sin(360.0/edges*(i-1)*2*PI/360.0), iR*cos(360.0/edges*(i-1)*2*PI/360.0));
+                        inner_side_points.emplace_back(iR*sin(phi*2*PI/360.0), iR*cos(phi*2*PI/360.0));
                     }
                 }
             }
@@ -933,8 +940,8 @@ void drawPartialCylinder(double length, double R /*radius*/, double iR /*inner r
 
 
         
-        outer_side_points.push_back((my_point){R*xl*sin((angle_cut_off_left)*2*PI/360.0), R*xl*cos(angle_cut_off_left*2*PI/360.0)});
-        outer_side_points.push_back((my_point){R*sin(360.0/edges*(i)*2*PI/360.0),R*cos(360.0/edges*(i)*2*PI/360.0)});
+        outer_side_points.emplace_back(R*xl*sin((angle_cut_off_left)*2*PI/360.0), R*xl*cos(angle_cut_off_left*2*PI/360.0));
+        outer_side_points.emplace_back(R*sin(360.0/edges*(i)*2*PI/360.0),R*cos(360.0/edges*(i)*2*PI/360.0));
 
         i=i+1; 
 
@@ -944,21 +951,21 @@ void drawPartialCylinder(double length, double R /*radius*/, double iR /*inner r
             if(360.0-phi <= angle_cut_off){
                 x = cos(2*PI/edges/2)/cos((360.0- (phi-360.0/edges/2)-angle_cut_off)*2*PI/360.0);
 
-                outer_side_points.push_back((my_point){R*x*sin((360.0-angle_cut_off)*2*PI/360.0), R*x*cos((360.0-angle_cut_off)*2*PI/360.0)});
+                outer_side_points.emplace_back(R*x*sin((360.0-angle_cut_off)*2*PI/360.0), R*x*cos((360.0-angle_cut_off)*2*PI/360.0));
                 //outer_side_points.push_back((my_point){R*x*sin((360.0-angle_cut_off)*2*PI/360.0), R*x*cos((360.0-angle_cut_off)*2*PI/360.0)});
                 break;
             }else{
-                outer_side_points.push_back((my_point){R*sin(phi*2*PI/360.0), R*cos(phi*2*PI/360.0)});
+                outer_side_points.emplace_back(R*sin(phi*2*PI/360.0), R*cos(phi*2*PI/360.0));
                 //if(i != 0){
                 //    outer_side_points.push_back((my_point){R*sin(phi*2*PI/360.0), R*cos(phi*2*PI/360.0)});
                 //}
             }
         }
 
-        for(unsigned int i=0;i<inner_side_points.size();i++){ //transform the points to inner rotate angle
-            my_point tmp = my_point(inner_side_points[i]);
-            inner_side_points[i].x=tmp.x*cos(irotate/360*2*PI) - sin(irotate/360*2*PI)*tmp.y;
-            inner_side_points[i].y=tmp.x*sin(irotate/360*2*PI) + tmp.y*cos(irotate/360.0*2*PI);
+        for(unsigned int i2=0;i2<inner_side_points.size();i2++){ //transform the points to inner rotate angle
+            my_point tmp = my_point(inner_side_points[i2]);
+            inner_side_points[i2].x=tmp.x*cos(irotate/360*2*PI) - sin(irotate/360*2*PI)*tmp.y;
+            inner_side_points[i2].y=tmp.x*sin(irotate/360*2*PI) + tmp.y*cos(irotate/360.0*2*PI);
         }
 
         for(j=0;j<2;j++){  //here do the drawing
@@ -1213,7 +1220,7 @@ static void renderBitmapString( float x, float y, void *font, char* string) {
 * A extra picking function, do the same as ced_get_selected,   *
 * without center the selected object                           *
 ***************************************************************/
-int ced_picking(int x,int y,GLfloat *wx,GLfloat *wy,GLfloat *wz){
+int ced_picking(int x,int y,GLfloat */*wx*/,GLfloat */*wy*/,GLfloat */*wz*/){
     mouse_x=x;
     mouse_y=y;
 
@@ -1530,7 +1537,7 @@ static void ced_draw_line(CED_Line *h){
 
 
 static unsigned CED_PICKING_TEXT_ID=0;
-static void ced_write_picking_text(CED_PICKING_TEXT *text){
+static void ced_write_picking_text(CED_PICKING_TEXT */*text*/){
 /*
     static int biggest_number_picking_text=0;
     if(text->id > biggest_number_picking_text){
@@ -1669,28 +1676,28 @@ static void ced_draw_geotube(CED_GeoTube *c){
         }
 
         for(; tmpz <= z0-2*(z0-z1); tmpz+=200){
-             for(double tmpr=d_i; tmpr < d_o; tmpr+=600){
+             for(double tmpr2=d_i; tmpr2 < d_o; tmpr2+=600){
                  for(double y=0;y<2*3.14-2*3.14*cut_angle/360.;y+=0.20){
                       //z0 left end
                       //z1 middle
                       //right z0-2*(z0-z1)
                       CED_Point tmp2;
-                      tmp2.x = tmpr*sin(y);
-                      tmp2.y = tmpr*cos(y);
+                      tmp2.x = tmpr2*sin(y);
+                      tmp2.y = tmpr2*cos(y);
                       tmp2.z = tmpz;
                       ced_add_objmap(&tmp2,20,0,c->type,1 );
 
                  } 
              }
 
-             for(double tmpr=d_i+300; tmpr < d_o; tmpr+=600){
+             for(double tmpr2=d_i+300; tmpr2 < d_o; tmpr2+=600){
                  for(double y=0.1;y<2*3.14-2*3.14*cut_angle/360.;y+=0.20){
                       //z0 left end
                       //z1 middle
                       //right z0-2*(z0-z1)
                       CED_Point tmp2;
-                      tmp2.x = tmpr*sin(y);
-                      tmp2.y = tmpr*cos(y);
+                      tmp2.x = tmpr2*sin(y);
+                      tmp2.y = tmpr2*cos(y);
                       tmp2.z = tmpz;
                       ced_add_objmap(&tmp2,20,0,c->type,1 );
 
@@ -2417,7 +2424,7 @@ static void ced_draw_legend(CED_Legend *legend){
 		break;
 		/** LIN */
 		case 'b':
-			strncpy( footer, "LIN", 3 );	
+			strncpy( footer, "LIN", sizeof(footer) );
 			renderBitmapString(x_min-x_offset_legend,y_min-y_offset_legend, font, footer);
 			glEnd();
 		break;

--- a/src/server/glced.cc
+++ b/src/server/glced.cc
@@ -155,7 +155,7 @@ static void set_world_size( float length) {
   axe[1][0] = WORLD_SIZE / 2. ;
   axe[2][1] = WORLD_SIZE / 2. ;
   axe[3][2] = WORLD_SIZE / 2. ;
-};
+}
 
 typedef GLfloat color_t[4];
 
@@ -506,8 +506,8 @@ void printFPS(void){
     GLfloat w=glutGet(GLUT_SCREEN_WIDTH);
     GLfloat h=glutGet(GLUT_SCREEN_HEIGHT); ;
 
-    int  WORLD_SIZE=1000; //static worldsize maybe will get problems in the future...
-    glOrtho(-WORLD_SIZE*w/h,WORLD_SIZE*w/h,-WORLD_SIZE,WORLD_SIZE, -15*WORLD_SIZE,15*WORLD_SIZE);
+    int  WORLD_SIZE2=1000; //static worldsize maybe will get problems in the future...
+    glOrtho(-WORLD_SIZE2*w/h,WORLD_SIZE2*w/h,-WORLD_SIZE2,WORLD_SIZE2, -15*WORLD_SIZE2,15*WORLD_SIZE2);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
 
@@ -602,10 +602,10 @@ void printShortcuts(void){
     shortcuts.push_back( "DATA LAYERS:" );
 
 
-    char label[MAX_STR_LEN+1];
+    char label[CED_MAX_LAYER_CHAR+128];
 
     for(i=0;i<NUMBER_DATA_LAYER;i++){
-        snprintf(label,MAX_STR_LEN+1, "(%s) [%c] %s%i: %s", isLayerVisible(i)?"X":"_",layer_keys[i], (i<10)?"0":"", i, layerDescription[i]);
+        snprintf(label,sizeof(label), "(%s) [%c] %s%i: %.*s", isLayerVisible(i)?"X":"_",layer_keys[i], (i<10)?"0":"", i, CED_MAX_LAYER_CHAR, layerDescription[i]);
         if(strlen(label) >= MAX_STR_LEN){
             label[MAX_STR_LEN-3]='.';
             label[MAX_STR_LEN-2]='.';
@@ -647,13 +647,13 @@ void printShortcuts(void){
     GLfloat w=glutGet(GLUT_WINDOW_WIDTH);
     GLfloat h=glutGet(GLUT_WINDOW_HEIGHT); ;
 
-    int  WORLD_SIZE=1000; //static worldsize maybe will get problems in the future...
+    int  WORLD_SIZE2=1000; //static worldsize maybe will get problems in the future...
 
-    //glOrtho(0,w,h, 0,0,15*WORLD_SIZE);
+    //glOrtho(0,w,h, 0,0,15*WORLD_SIZE2);
 
-    //glOrtho(0,w,h,-10,0,15*WORLD_SIZE);
+    //glOrtho(0,w,h,-10,0,15*WORLD_SIZE2);
 
-    glOrtho(0,w,h,-1*height,0,15*WORLD_SIZE);
+    glOrtho(0,w,h,-1*height,0,15*WORLD_SIZE2);
 
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
@@ -1430,7 +1430,7 @@ void loadSettings(int slot){
 
 
 
-void mouseWheel(int button, int dir, int x, int y){ //hauke
+void mouseWheel(int /*button*/, int dir, int /*x*/, int /*y*/){ //hauke
     if(dir > 0){
         selectFromMenu(VIEW_ZOOM_IN);
     }else{
@@ -1894,7 +1894,7 @@ static void keypressed(unsigned char key, int x, int y) {
   }
 }
 
-static void SpecialKey( int key, int x, int y ){
+static void SpecialKey( int key, int /*x*/, int /*y*/ ){
    switch (key) {
    case GLUT_KEY_RIGHT:
        mm.mv.z+=50.;
@@ -1973,7 +1973,7 @@ static void motion(int x,int y){
     glutPostRedisplay();
 }
 
-static void timer (int val)
+static void timer (int /*val*/)
 {
     //change timer for testing to 1
     fd_set fds;
@@ -2185,7 +2185,7 @@ void subReshape (int w, int h)
   glMatrixMode (GL_PROJECTION);
   glLoadIdentity ();
   gluOrtho2D (0.0F, 1.0F, 0.0F, 1.0F);
-};
+}
 
 void writeString(char *str,int x,int y){
     int i;
@@ -2230,7 +2230,7 @@ void toggleHelpWindow(void){ //hauke
 //    glutSetWindow(mainWindow);
 }
 
-void updateLayerEntryInPopupMenu(int id){ //id is layer id, not menu id!
+void updateLayerEntryInPopupMenu(int /*id*/){ //id is layer id, not menu id!
 //    char string[200];
 //    char tmp[41];
 //    if(id < 0 || id > NUMBER_POPUP_LAYER-1){
@@ -2267,7 +2267,7 @@ void updateScreenshotMenu(void){
 //    glutChangeToMenuEntry(5,tmp,SAVE_IMAGE100);
 //
 }
-void updateSaveLoadMenu(int id){ //id is save id, not menu id!
+void updateSaveLoadMenu(int /*id*/){ //id is save id, not menu id!
 //    struct stat s;
 //
 //
@@ -2291,7 +2291,7 @@ void updateSaveLoadMenu(int id){ //id is save id, not menu id!
 }
 
 
-void updateLayerEntryDetector(int id){ //id is layer id, not menu id!
+void updateLayerEntryDetector(int /*id*/){ //id is layer id, not menu id!
 //    char string[200];
 //    char tmp[101];
 //    if(id < NUMBER_DATA_LAYER || id > NUMBER_DETECTOR_LAYER+NUMBER_DATA_LAYER-1 || id > CED_MAX_LAYER-1 || id < 0){
@@ -2394,10 +2394,10 @@ void selectFromMenu(int id){ //hauke
             if(!ced_picking(popupmenu->x_click,popupmenu->y_click ,&mm.mv.x,&mm.mv.y,&mm.mv.z)){
                struct __glutSocketList *sock;
                sock=__glutSockets;
-               int id = SELECTED_ID;
+               int selid = SELECTED_ID;
                //printf(" ced_get_selected : socket connected: %d", sock->fd );
                if(client_connected){
-                    send( sock->fd , &id , sizeof(int) , 0 );
+                    send( sock->fd , &selid , sizeof(int) , 0 );
                 }
             }
             break;
@@ -2534,6 +2534,7 @@ void selectFromMenu(int id){ //hauke
 
         case BGCOLOR_USER:
             set_bg_color(userDefinedBGColor[0],userDefinedBGColor[1], userDefinedBGColor[2], userDefinedBGColor[3]);
+            break;
 
 
         case VIEW_RESET:
@@ -3520,9 +3521,9 @@ void buildPopUpMenu(int x, int y){
             }
             popupmenu->addItem(phicuts);
 
-            char tmp[200];
-            snprintf(tmp,199,"Z-cut (%.0f)",setting.detector_cut_z[layer-NUMBER_DATA_LAYER]);
-            CED_SubSubMenu *zcuts=new CED_SubSubMenu(tmp);
+            char tmp2[200];
+            snprintf(tmp2,199,"Z-cut (%.0f)",setting.detector_cut_z[layer-NUMBER_DATA_LAYER]);
+            CED_SubSubMenu *zcuts=new CED_SubSubMenu(tmp2);
             zcuts->addItem(new CED_SubSubMenu("Cut at z=-6000", LAYER_CUT_Z_M6000));
             zcuts->addItem(new CED_SubSubMenu("Cut at z=-4000", LAYER_CUT_Z_M4000));
             zcuts->addItem(new CED_SubSubMenu("Cut at z=-2000", LAYER_CUT_Z_M2000));
@@ -3542,8 +3543,8 @@ void buildPopUpMenu(int x, int y){
 
 
 
-            snprintf(tmp,199,"Transparency (%.0f)",100*setting.detector_trans[layer-NUMBER_DATA_LAYER]);
-            CED_SubSubMenu *trans=new CED_SubSubMenu(tmp);
+            snprintf(tmp2,199,"Transparency (%.0f)",100*setting.detector_trans[layer-NUMBER_DATA_LAYER]);
+            CED_SubSubMenu *trans=new CED_SubSubMenu(tmp2);
             trans->addItem(new CED_SubSubMenu("    0%",LAYER_TRANS0));
             trans->addItem(new CED_SubSubMenu("  40%", LAYER_TRANS40));
             trans->addItem(new CED_SubSubMenu("  60%", LAYER_TRANS60));
@@ -3670,31 +3671,31 @@ void buildLayerMenus(void){
     datalayermenu=new CED_SubSubMenu("Data layers",0);
     int i;
     char str[2000];
-    unsigned max=150;
+    static const unsigned max=150;
     char tmp[max+1];
     for(i=0;i<NUMBER_POPUP_LAYER;i++){
 //        std::cout << "description: " << layerDescription[i] << std::endl;
         if(strlen(layerDescription[i]) > max-1){
-            snprintf(tmp,max-3,"%s",layerDescription[i]);
-            sprintf(tmp,"%s...",tmp);
+            memcpy (tmp, layerDescription[i], max-3);
+            strcpy (tmp+max-3, "...");
         }else{
             sprintf(tmp,"%s",layerDescription[i]);
         }
 
-        sprintf(str,"%s %s%i [%c]: %s", isLayerVisible(i)?"[X]":"[ ]", (i < 10)?"  ":"" ,i, layer_keys[i], tmp);
+        snprintf(str,sizeof(str),"%s %s%i [%c]: %s", isLayerVisible(i)?"[X]":"[ ]", (i < 10)?"  ":"" ,i, layer_keys[i], tmp);
         //std::cout << str << std::endl;
         datalayermenu->addItem(new CED_SubSubMenu(str,LAYER_0+i));
     }
     for(i=NUMBER_DATA_LAYER;i<NUMBER_DETECTOR_LAYER+NUMBER_DATA_LAYER;i++){
         //sprintf(str,"Detector Layer %s%i [%c]: %s", (i < 10)?"  ":"" ,i, layer_keys[i], layerDescription[i]);
         if(strlen(layerDescription[i]) > max){
-            snprintf(tmp,max-3,"%s",layerDescription[i]);
-            sprintf(tmp,"%s...",tmp);
+            memcpy (tmp, layerDescription[i], max-3);
+            strcpy (tmp+max-3, "...");
         }else{
             sprintf(tmp,"%s",layerDescription[i]);
         }
 
-        sprintf(str,"%s %s%i: %s", isLayerVisible(i)?"[X]":"[ ]",(i < 10)?"  ":"" ,i, layerDescription[i]);
+        snprintf(str,sizeof(str),"%s %s%i: %s", isLayerVisible(i)?"[X]":"[ ]",(i < 10)?"  ":"" ,i, tmp);
         detectorlayermenu->addItem(new CED_SubSubMenu(str,DETECTOR1+i-NUMBER_DATA_LAYER));
     }
 
@@ -3724,8 +3725,8 @@ void buildMainMenu(void){
 
     layers->addItem(new CED_SubSubMenu("---", AXES));
     bool result=true;
-    for(int i=0;i<NUMBER_DATA_LAYER;i++){
-        if(setting.layer[i] == false){
+    for(int i2=0;i2<NUMBER_DATA_LAYER;i2++){
+        if(setting.layer[i2] == false){
             result=false;
             break;
         }
@@ -4222,8 +4223,8 @@ int buildMenuPopup(void){ //hauke
     glutAddMenuEntry("Slot 4",LOAD4);
     glutAddMenuEntry("Slot 5",LOAD5);
 
-    for(int i=1;i<=5;i++){
-        updateSaveLoadMenu(i);
+    for(int i2=1;i2<=5;i2++){
+        updateSaveLoadMenu(i2);
     }
 
 
@@ -4610,7 +4611,7 @@ int save_pixmap_as_bmp(unsigned char *buffer_all,const char *name,unsigned int w
     return(0);
 }
 
-void screenshot(const char *name, int times)
+void screenshot(const char */*name*/, int times)
 {
     if(times > 100){
         std::cout << "Sorry 100x100 are the max value" << std::endl ;


### PR DESCRIPTION
Fix compilation warnings seen with current gcc versions.
    
  - Local variable declaration shadowing previous declaration.
  - Avoid use of gcc compound-literal extension.
  - Unused function parameters.
  - Change macro to inline function; avoids integer comparison warnings.
  - Avoid variable-length array extension.
  - Fix length in strncpy call.
  - Fix some sprintf truncation/overflow warnings.
  - Spurious switch fallthrough.
   - Remove some unneeded semicolons

Also fix -Weffc++ warnings.

BEGINRELEASENOTES
- Fix a number of compilation warnings.
ENDRELEASENOTES