### PR TITLE
Convert from latin-1 encoding to utf-8.

### DIFF
--- a/src/client/glut_socks.cc
+++ b/src/client/glut_socks.cc
@@ -2,7 +2,7 @@
  * Server (GLUT) side. 
  *
  * Alexey Zhelezov, DESY/ITEP, 2005 
- * July 2005, Jörgen Samson: small fix to keep
+ * July 2005, JÃ¶rgen Samson: small fix to keep
  *            TCP/IP connection alive if data
  *            is temporary not available
  */


### PR DESCRIPTION
Avoids a warning from clang.

BEGINRELEASENOTES
- Update character encoding in a comment from latin-1 to utf-8 to avoid a warning from clang.
ENDRELEASENOTES